### PR TITLE
YDENV-140 fix: Ensure imported availability does not go below zero

### DIFF
--- a/modules/openy_traction_rec_import/src/Plugin/migrate/process/Availability.php
+++ b/modules/openy_traction_rec_import/src/Plugin/migrate/process/Availability.php
@@ -25,7 +25,9 @@ class Availability extends ProcessPluginBase {
         return 100;
       }
 
-      return (int) $value;
+      // Traction Rec can allow classes to be overbooked, resulting in a value
+      // for Total_Capacity_Available that's < 0. We don't want that.
+      return max((int) $value, 0);
     }
     catch (\Exception $e) {
       throw new MigrateSkipRowException($e->getMessage());


### PR DESCRIPTION
Some Sessions have been coming through with a negative value for "Total_Capacity_Available", which is coming through to the front-end. 

![image](https://github.com/YCloudYUSA/openy_traction_rec/assets/238201/decada05-fbf2-4759-96af-3f1b54640e1b)

This is because in Traction Rec staff can overbook a class if they have permissions, resulting in `Total_Capacity_Available` being passed to the import as negative.

This change sets `max( Total_Capacity_Available, 0)` so that we'll never have an availability less than zero. 

This will require sites with data to run `drush tr:rollback` and then re-import.