### PR TITLE
YDENV-140 fix: Pull description from Course Session if it doesn't exist on Course

### DIFF
--- a/modules/openy_traction_rec_import/config/install/migrate_plus.migration.tr_sessions_import.yml
+++ b/modules/openy_traction_rec_import/config/install/migrate_plus.migration.tr_sessions_import.yml
@@ -45,6 +45,14 @@ source:
       label: Course Rich Description
       selector: /Course_Session/Course/Rich_Description
     -
+      name: course_session_description
+      label: Course Session Description
+      selector: /Course_Session/Description
+    -
+      name: course_session_rich_description
+      label: Course Session Rich Description
+      selector: /Course_Session/Rich_Description
+    -
       name: start_date
       label: 'Start Date'
       selector: /Course_Option/Start_Date
@@ -139,6 +147,8 @@ process:
     source:
       - course_rich_description
       - course_description
+      - course_session_rich_description
+      - course_session_description
   field_availability:
     plugin: tr_availability
     source: spots_available

--- a/modules/openy_traction_rec_import/openy_traction_rec_import.install
+++ b/modules/openy_traction_rec_import/openy_traction_rec_import.install
@@ -21,3 +21,13 @@ function openy_traction_rec_import_requirements($phase) {
   }
   return $requirements;
 }
+
+/**
+ * Update sessions import with Course Session Description.
+ */
+function openy_traction_rec_import_update_10001() {
+  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_traction_rec_import') . '/config/install';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs(['migrate_plus.migration.tr_sessions_import']);
+}

--- a/src/TractionRec.php
+++ b/src/TractionRec.php
@@ -155,6 +155,8 @@ class TractionRec implements TractionRecInterface {
         TREX1__Course_Option__r.TREX1__Type__c,
         TREX1__Course_Option__r.TREX1__Unlimited_Capacity__c,
         TREX1__Course_Session__r.id,
+        TREX1__Course_Session__r.TREX1__Description__c,
+        TREX1__Course_Session__r.TREX1__Rich_Description__c,
         TREX1__Course_Session__r.TREX1__Course__r.name,
         TREX1__Course_Session__r.TREX1__Course__r.id,
         TREX1__Course_Session__r.TREX1__Course__r.TREX1__Description__c,


### PR DESCRIPTION
Depending on their Traction Rec configuration, Ys may add a description on the Course or Course Session object. Since both of these objects map to the Drupal "Session", we should check all of these fields, but only take the most specific one that exists. 

This adds that logic, but should not affect any content with an existing description.

requested by YDEN