### PR TITLE
Check that Course Session Option is available online

### DIFF
--- a/src/TractionRec.php
+++ b/src/TractionRec.php
@@ -167,6 +167,7 @@ class TractionRec implements TractionRecInterface {
         TREX1__Course_Option__r.TREX1__Waitlist_Total__c
       FROM TREX1__Course_Session_Option__c
       WHERE TREX1__Course_Option__r.TREX1__Available_Online__c = true
+        AND TREX1__Course_Session_Option__c.TREX1__Available_Online__c = true
         AND TREX1__Course_Option__r.TREX1__Day_of_Week__c  != null
         AND TREX1__Course_Option__r.TREX1__Register_Online_To_Date__c > YESTERDAY
         AND TREX1__Course_Option__r.TREX1__End_Date__c >= TODAY


### PR DESCRIPTION
Adds a filter criteria to confirm that the Course Session Option is available online in addition to the Course Option. This can alleviate an issue where the course Session is marked available but it's parent is not, so links to registration would be broken. 

Requested by YMCA Denver. YDENV-175