### PR TITLE
Respect "Available Online" From date in Course Option

### DIFF
--- a/src/TractionRec.php
+++ b/src/TractionRec.php
@@ -168,7 +168,7 @@ class TractionRec implements TractionRecInterface {
       FROM TREX1__Course_Session_Option__c
       WHERE TREX1__Course_Option__r.TREX1__Available_Online__c = true
         AND TREX1__Course_Option__r.TREX1__Day_of_Week__c  != null
-        AND TREX1__Course_Option__r.TREX1__Register_Online_From_Date__c >= TODAY
+        AND TREX1__Course_Option__r.TREX1__Register_Online_From_Date__c <= TODAY
         AND TREX1__Course_Option__r.TREX1__Register_Online_To_Date__c > YESTERDAY
         AND TREX1__Course_Option__r.TREX1__End_Date__c >= TODAY
         AND TREX1__Course_Option__r.TREX1__Start_Date__c != null');

--- a/src/TractionRec.php
+++ b/src/TractionRec.php
@@ -168,6 +168,7 @@ class TractionRec implements TractionRecInterface {
       FROM TREX1__Course_Session_Option__c
       WHERE TREX1__Course_Option__r.TREX1__Available_Online__c = true
         AND TREX1__Course_Option__r.TREX1__Day_of_Week__c  != null
+        AND TREX1__Course_Option__r.TREX1__Register_Online_From_Date__c >= TODAY
         AND TREX1__Course_Option__r.TREX1__Register_Online_To_Date__c > YESTERDAY
         AND TREX1__Course_Option__r.TREX1__End_Date__c >= TODAY
         AND TREX1__Course_Option__r.TREX1__Start_Date__c != null');


### PR DESCRIPTION
Currently Sessions show up in AF even if their "Available Online" status is in the future. This can result in inaccessible links when users are sent to Traction Rec. This change respects the `TREX1__Course_Option__r.TREX1__Register_Online_From_Date__c` field and will not show sessions if they should not be available online.

requested by YMCA Wichita