### PR TITLE
Add ability to fetch Course sessions.

### DIFF
--- a/src/TractionRec.php
+++ b/src/TractionRec.php
@@ -90,7 +90,32 @@ class TractionRec implements TractionRecInterface {
       return $this->simplify($result);
     }
     catch (\Exception | GuzzleException $e) {
-      $message = 'Can\'t load the list of classes: ' . $e->getMessage();
+      $message = 'Can\'t load the list of courses: ' . $e->getMessage();
+      $this->logger->error($message);
+      return [];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadCourseSessions(): array {
+    try {
+      $result = $this->tractionRecClient->executeQuery('SELECT
+        TREX1__Course_Session__c.id,
+        TREX1__Course_Session__c.name,
+        TREX1__Course_Session__c.TREX1__Description__c,
+        TREX1__Course_Session__c.TREX1__Rich_Description__c,
+        TREX1__Course_Session__c.TREX1__Available__c,
+        TREX1__Course_Session__c.TREX1__Course__r.id,
+        TREX1__Course_Session__c.TREX1__Course__r.name
+      FROM TREX1__Course_Session__c
+      WHERE TREX1__Available_Online__c = true');
+
+      return $this->simplify($result);
+    }
+    catch (\Exception | GuzzleException $e) {
+      $message = 'Can\'t load the list of course sessions: ' . $e->getMessage();
       $this->logger->error($message);
       return [];
     }
@@ -231,7 +256,7 @@ class TractionRec implements TractionRecInterface {
       return $this->simplify($result);
     }
     catch (\Exception | GuzzleException $e) {
-      $message = 'Can\'t load the list of program category tags: ' . $e->getMessage();
+      $message = 'Can\'t load the list of memberships: ' . $e->getMessage();
       $this->logger->error($message);
       return [];
     }

--- a/src/TractionRecInterface.php
+++ b/src/TractionRecInterface.php
@@ -24,6 +24,14 @@ interface TractionRecInterface {
   public function loadCourses(): array;
 
   /**
+   * Load the list of all TractionRec course sessions.
+   *
+   * @return array
+   *   The list of course sessions.
+   */
+  public function loadCourseSessions(): array;
+
+  /**
    * Load TractionRec Program Categories Tags.
    *
    * @return array


### PR DESCRIPTION
This PR won't change the behavior of the existing logic but adds the ability to fetch Course sessions, which can be used in custom or overridden functions.

Currently, we use the same TractionRec Course object for both Drupal's class and activity.

https://github.com/YCloudYUSA/openy_traction_rec/blob/main/modules/openy_traction_rec_import/config/install/migrate_plus.migration.tr_classes_import.yml#L17
https://github.com/YCloudYUSA/openy_traction_rec/blob/main/modules/openy_traction_rec_import/config/install/migrate_plus.migration.tr_activities_import.yml#L17

One of our clients has decided to change this hierarchy. Course sessions may be useful in the future.
