### PR TITLE
Update firebase/php-jwt dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
         "drupal/migrate_plus": "^5.2 || ^6",
         "drupal/migrate_tools": "^5.1 || ^6",
         "drupal/key": "^1.15",
-        "firebase/php-jwt": "^5.2"
+        "firebase/php-jwt": "^6.0"
     }
 }


### PR DESCRIPTION
This PR addresses the [security issue on the Firebase PHP-JWT](https://github.com/advisories/GHSA-8xf4-w7qw-pjjw) dependency by updating it to ^6.0. 

I tested on a project and had no issues with it, but it would be great to test it in more projects.