### PR TITLE
Changes to the traction rec importer to support migrate_tools ^6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         "ycloudyusa/yusaopeny_activity_finder": "^4.0 || *",
         "open-y-subprojects/openy_features": "^1.5 || *",
         "drush/drush": "^12 || ^11 || ^10",
-        "drupal/migrate_plus": "^5.2 || ^6",
-        "drupal/migrate_tools": "^5.1 || ^6",
+        "drupal/migrate_plus": "^6",
+        "drupal/migrate_tools": "^6.1",
         "drupal/key": "^1.15",
         "firebase/php-jwt": "^6.0"
     }

--- a/modules/openy_traction_rec_import/openy_traction_rec_import.services.yml
+++ b/modules/openy_traction_rec_import/openy_traction_rec_import.services.yml
@@ -8,6 +8,9 @@ services:
       - '@plugin.manager.migration'
       - '@entity_type.manager'
       - '@file_system'
+      - '@keyvalue'
+      - '@datetime.time'
+      - '@string_translation'
 
   openy_traction_rec_import.cleaner:
     class: 'Drupal\openy_traction_rec_import\Cleaner'


### PR DESCRIPTION
We updated the migrate_tools module to version 6.1.2, which broke the `--update` option in the `tr:import` command. We realized that it is due to a change in the migrate_tools module, including new parameters to [the MigrateExecutable class constructor](https://git.drupalcode.org/project/migrate_tools/-/blob/6.0.x/src/MigrateExecutable.php?ref_type=heads#L120), that ended up messing with the code we have [here](https://github.com/YCloudYUSA/openy_traction_rec/blob/main/modules/openy_traction_rec_import/src/Importer.php#L175).

I also updated the required versions of drupal/migrate_plus and drupal/migrate_tools in the composer.json file to resolve the version conflict.