### PR TITLE
Fix mermaid erDiagram syntax for Hugo compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,72 +246,72 @@ Field types are taken from Salesforce's **Setup** > **Object Manager** > **{Enti
 erDiagram
     Program_Category__c {
         id Id
-        text(80) Name
+        "text(80)" Name
     }
     Program__c {
         id Id
-        text(80) Name
+        "text(80)" Name
         checkbox Available__c
-        textArea(255) Description__c
+        "textArea(255)" Description__c
     }
     Program_Category_Tag__c {
         id Id
         autoNumber Name
-        lookup(Program) Program__c
-        lookup(Program_Category) Program_Category_c
+        "lookup(Program)" Program__c
+        "lookup(Program_Category)" Program_Category_c
     }
     Course__c {
         id Id
-        text(80) Name
+        "text(80)" Name
         checkbox Available__c
-        text(128) Code__c
-        longTextArea(640) Description__c
-        lookup(Program) Program__c
+        "text(128)" Code__c
+        "longTextArea(640)" Description__c
+        "lookup(Program)" Program__c
         richTextArea Rich_Description__c
     }
     Course_Session__c {
         id Id
-        text(80) Name
+        "text(80)" Name
         checkbox Available__C
-        text(128) Code__c
-        lookup(Course) Course__c
-        longTextArea(640) Description__c
-        number(18_0) Num_Option_Entitlements__c
-        lookup(ProductAndDiscount) Product__C
+        "text(128)" Code__c
+        "lookup(Course)" Course__c
+        "longTextArea(640)" Description__c
+        "number(18_0)" Num_Option_Entitlements__c
+        "lookup(ProductAndDiscount)" Product__C
         richTextArea Rich_Description__c
         sum Total_Option_Capacity__c
-        formula(number) Total_Option_Capacity_Remaining__C
+        "formula(number)" Total_Option_Capacity_Remaining__C
         sum Total_Option_Registrants__c
         count Total_Options_Available__c
     }
     Course_Option__c {
         id Id
-        text(80) Name
-        number(3_1) Age_Max__c
-        number(3_1) Age_Min__c
+        "text(80)" Name
+        "number(3_1)" Age_Max__c
+        "number(3_1)" Age_Min__c
         checkbox Available__c
-        number(18_0) Capacity__c
-        picklist(multiSelect) Day_of_Week__c
+        "number(18_0)" Capacity__c
+        "picklist(multiSelect)" Day_of_Week__c
         date End_Date__c
-        text(8) End_Time__c
-        text(128) Instructor__c
-        lookup(ProductAndDiscount) Product__c
-        number(18_0) Registration_Total_c
-        longTextArea(3500) Setup_Notes__c
-        number(3_0) Setup_Time_Required___c
+        "text(8)" End_Time__c
+        "text(128)" Instructor__c
+        "lookup(ProductAndDiscount)" Product__c
+        "number(18_0)" Registration_Total_c
+        "longTextArea(3500)" Setup_Notes__c
+        "number(3_0)" Setup_Time_Required___c
         date Start_Date__c
-        text(8) Start_Time__c
-        longTextArea(3500) Tear_Down_Notes__c
-        number(3_0) Tear_Down_Time_Required__C
+        "text(8)" Start_Time__c
+        "longTextArea(3500)" Tear_Down_Notes__c
+        "number(3_0)" Tear_Down_Time_Required__C
     }
     Course_Session_Option__c {
         id Id
         autoNumber Name
-        lookup(CourseOption) Course_Option__c
-        masterDetail(CourseSession) Course_Session__c
+        "lookup(CourseOption)" Course_Option__c
+        "masterDetail(CourseSession)" Course_Session__c
         checkbox Option_Available__c
-        number(18_0) Option_Capacity__c
-        number(18_0) Option_Registration_Total__c
+        "number(18_0)" Option_Capacity__c
+        "number(18_0)" Option_Registration_Total__c
     }
     Program_Category__c ||--|{ Program_Category_Tag__c : ""
     Program__c ||--|{ Program_Category_Tag__c : ""


### PR DESCRIPTION
## Summary
- Quote 36 field types containing parentheses in the Data Model mermaid diagram
- Fixes Mermaid 11.x parsing errors when rendered via Hugo

## Context
The mermaid erDiagram in README.md works on GitHub but fails on Hugo-rendered docs site with "Syntax error in text" (mermaid version 11.12.2).

**Broken page:** https://ds-docs.y.org/docs/development/program-event-framework/traction-rec/

Field types like `text(80)`, `number(18_0)`, `lookup(Program)` need quotes in newer Mermaid versions.

## Test plan
- [ ] Verify diagram renders on GitHub after merge
- [ ] Rebuild yusaopeny_docs and verify diagram renders on https://ds-docs.y.org/